### PR TITLE
Fix formatting parameter name

### DIFF
--- a/src/ros_d2/ros_d2/helpers/convert.py
+++ b/src/ros_d2/ros_d2/helpers/convert.py
@@ -26,7 +26,7 @@ def convert(ros_architecture: RosArchitecture, verbose: bool = False) -> str:
             shape = D2Shape(
                 name=topic.name,
                 shape=Shape.classs,
-                topic=D2Text(text=concat_strings(topic.types), format=""),
+                topic=D2Text(text=concat_strings(topic.types), formatting=""),
             )
         else:
             shape = D2Shape(name=topic.name, shape=Shape.classs)


### PR DESCRIPTION
The `format` parameter was changed to `formatting` in https://github.com/MrBlenny/py-d2/pull/15.